### PR TITLE
Fix weather not loading automatically on launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ $(APP_BUNDLE): $(SWIFT_FILES) WeatherWallpaper/Web/* WeatherWallpaper/Info.plist
 	     -e 's/$$(PRODUCT_NAME)/Weather Wallpaper/g' \
 	     -e 's/$$(MACOSX_DEPLOYMENT_TARGET)/13.0/g' \
 	     WeatherWallpaper/Info.plist > $(CONTENTS)/Info.plist
-	@cp WeatherWallpaper/Web/* $(RESOURCES)/Web/
+	@cp -R WeatherWallpaper/Web/* $(RESOURCES)/Web/
 	@echo "Built: $(APP_BUNDLE)"
 
 run: $(APP_BUNDLE)

--- a/WeatherWallpaper/Web/weather.js
+++ b/WeatherWallpaper/Web/weather.js
@@ -293,7 +293,7 @@ function render(data) {
 }
 
 async function fetchWeather(loc) {
-  if (!window.isPrimaryView || appPaused) return;
+  if (window.isPrimaryView === false || appPaused) return;
 
   var unitSystem = getUnitSystem();
   var temperatureUnit = unitSystem === 'metric' ? 'celsius' : 'fahrenheit';
@@ -513,7 +513,7 @@ window.addEventListener('locationUpdated', async function (e) {
   if (window.globeSetCity) window.globeSetCity(lat, lon);
 
   // Secondary views stop here and wait for dataRelay for the rest
-  if (!window.isPrimaryView) return;
+  if (window.isPrimaryView === false) return;
 
   var name = e.detail.name || (lat.toFixed(2) + ', ' + lon.toFixed(2));
   var loc = { name: name, lat: lat, lon: lon };
@@ -527,7 +527,7 @@ window.addEventListener('locationUpdated', async function (e) {
 
   try {
     var data = await fetchWeather(loc);
-    render(data);
+    if (data) render(data);
   } catch (e) {
     console.error('Weather fetch failed:', e);
   }
@@ -562,10 +562,8 @@ window.addEventListener('locationUpdated', async function (e) {
   }
 
   try {
-    if (window.isPrimaryView) {
-      var data = await fetchWeather(loc);
-      render(data);
-    }
+    var data = await fetchWeather(loc);
+    if (data) render(data);
   } catch (err) {
     console.error('Weather fetch failed:', err);
     if (!cached) document.getElementById('condition').textContent = 'Unable to load weather';
@@ -576,7 +574,7 @@ window.addEventListener('locationUpdated', async function (e) {
     var loc = getLocation();
     try {
       var data = await fetchWeather(loc);
-      render(data);
+      if (data) render(data);
     } catch (e) {
       console.warn('Weather auto-refresh failed:', e);
     }


### PR DESCRIPTION
## Summary
- Fix `isPrimaryView` guard using `!window.isPrimaryView` which blocked weather fetch when the flag was `undefined` (before Swift injects it). Changed to strict `=== false` comparison in both `fetchWeather()` and the `locationUpdated` event handler.
- Add null checks on `render()` calls to prevent crashes when `fetchWeather` returns early.
- Fix Makefile `cp` → `cp -R` to handle `fonts/` subdirectory.

## Test plan
- [ ] Launch app fresh — weather should load automatically without clicking "Refresh Location"
- [ ] Multi-monitor: secondary views should still receive data via relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)