### PR TITLE
fix: Live flights broken due to WKWebView CORS and OpenSky OAuth2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built with MapboxGL, Swift, and WebKit. Entirely vibe-coded with Claude.
 
 - macOS 13.0+
 - A free [Mapbox access token](https://account.mapbox.com/access-tokens/) (required)
+- An [OpenSky Network](https://opensky-network.org/) account with an OAuth2 API client (required for live flights)
 - A [Google Pollen API key](https://console.cloud.google.com/) (optional, for pollen data)
 
 ## Install
@@ -44,6 +45,7 @@ Requires Xcode Command Line Tools (`xcode-select --install`).
 1. Launch the app — a globe icon appears in your menu bar
 2. Click the icon → **Set Mapbox Token…** → paste your `pk.eyJ…` token
 3. The globe renders on your desktop
+4. To enable live flights: create a free account at [opensky-network.org](https://opensky-network.org), go to **My OpenSky → Account**, create an API client, then click **Set OpenSky Credentials…** in the menu and paste your `client_id` and `client_secret`
 
 ## Menu Bar
 
@@ -53,6 +55,7 @@ Requires Xcode Command Line Tools (`xcode-select --install`).
 | Search Location… | Geocode a city/place and fly there |
 | Set Mapbox Token… | Enter your Mapbox public token |
 | Set Pollen API Key… | Enter your Google Pollen API key |
+| Set OpenSky Credentials… | Enter your OpenSky OAuth2 client ID and secret |
 | Zoom: Globe / Country / City / Street | Change zoom level (radio select) |
 | Show Flights | Toggle live flight tracking |
 | Show Weather Radar | Toggle precipitation overlay |
@@ -64,7 +67,7 @@ Requires Xcode Command Line Tools (`xcode-select --install`).
 ## APIs Used
 
 - [Mapbox GL JS](https://www.mapbox.com/) — 3D globe rendering
-- [OpenSky Network](https://opensky-network.org/) — live flight data
+- [OpenSky Network](https://opensky-network.org/) — live flight data (fetched via Swift `URLSession` to avoid WKWebView CORS restrictions; requires OAuth2 credentials)
 - [RainViewer](https://www.rainviewer.com/api.html) — weather radar tiles (free, no key)
 - [Open-Meteo](https://open-meteo.com/) — air quality data (free, no key)
 - [Google Pollen API](https://developers.google.com/maps/documentation/pollen) — pollen forecasts

--- a/WeatherWallpaper/AppDelegate.swift
+++ b/WeatherWallpaper/AppDelegate.swift
@@ -16,6 +16,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var currentUnitSystem: String = "imperial"
     private let geocoder = CLGeocoder()
     private var geocodeCache: [String: String] = [:]
+    private var openSkyTokenTimer: Timer?
+    private var flightFetchTimer: Timer?
+
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if let savedUnit = UserDefaults.standard.string(forKey: "unit-system"), ["imperial", "metric"].contains(savedUnit) {
@@ -64,6 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Search Location…", action: #selector(searchLocation), keyEquivalent: "l"))
         menu.addItem(NSMenuItem(title: "Set Mapbox Token…", action: #selector(setMapboxToken), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Set Pollen API Key…", action: #selector(setPollenApiKey), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: "Set OpenSky Credentials…", action: #selector(setOpenSkyCredentials), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
 
         let zoomGlobe = NSMenuItem(title: "Zoom: Globe", action: #selector(setZoomGlobe(_:)), keyEquivalent: "")
@@ -213,6 +217,46 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @objc private func setOpenSkyCredentials() {
+        let alert = NSAlert()
+        alert.messageText = "OpenSky Network Credentials"
+        alert.informativeText = "Enter your OpenSky OAuth2 client credentials.\nCreate them at opensky-network.org → My OpenSky → Account."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let stack = NSStackView(frame: NSRect(x: 0, y: 0, width: 360, height: 56))
+        stack.orientation = .vertical
+        stack.spacing = 8
+        stack.alignment = .leading
+
+        let clientIdField = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+        clientIdField.placeholderString = "Client ID"
+        clientIdField.stringValue = UserDefaults.standard.string(forKey: "opensky-client-id") ?? ""
+
+        let clientSecretField = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+        clientSecretField.placeholderString = "Client Secret"
+        clientSecretField.stringValue = UserDefaults.standard.string(forKey: "opensky-client-secret") ?? ""
+
+        stack.addArrangedSubview(clientIdField)
+        stack.addArrangedSubview(clientSecretField)
+        alert.accessoryView = stack
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            let clientId = clientIdField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            let clientSecret = clientSecretField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !clientId.isEmpty && !clientSecret.isEmpty {
+                UserDefaults.standard.set(clientId, forKey: "opensky-client-id")
+                UserDefaults.standard.set(clientSecret, forKey: "opensky-client-secret")
+                desktopManager.injectOpenSkyCredentials(clientId: clientId, clientSecret: clientSecret)
+                // Immediately fetch a fresh token now that we have credentials
+                fetchAndInjectOpenSkyToken()
+            }
+        }
+    }
+
     // MARK: - Zoom
 
     private func updateZoomCheckmarks() {
@@ -286,7 +330,95 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func toggleFlights(_ sender: NSMenuItem) {
         flightsEnabled.toggle()
         sender.state = flightsEnabled ? .on : .off
-        desktopManager.injectFlightsToggle(flightsEnabled)
+        if flightsEnabled {
+            fetchAndInjectOpenSkyToken { [weak self] in
+                self?.desktopManager.injectFlightsToggle(true)
+                self?.startFlightFetchTimer()
+            }
+        } else {
+            flightFetchTimer?.invalidate()
+            flightFetchTimer = nil
+            desktopManager.injectFlightsToggle(false)
+        }
+    }
+
+    private func startFlightFetchTimer() {
+        flightFetchTimer?.invalidate()
+        fetchFlightsNative() // immediate first fetch
+        flightFetchTimer = Timer.scheduledTimer(withTimeInterval: 120, repeats: true) { [weak self] _ in
+            self?.fetchFlightsNative()
+        }
+    }
+
+    private func fetchFlightsNative() {
+        guard flightsEnabled else { return }
+        var urlComponents = URLComponents(string: "https://opensky-network.org/api/states/all")!
+        urlComponents.queryItems = [
+            URLQueryItem(name: "lamin", value: "-90"),
+            URLQueryItem(name: "lomin", value: "-180"),
+            URLQueryItem(name: "lamax", value: "90"),
+            URLQueryItem(name: "lomax", value: "180")
+        ]
+        guard let url = urlComponents.url else { return }
+        var request = URLRequest(url: url)
+        if let token = UserDefaults.standard.string(forKey: "opensky-bearer-token"), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            DispatchQueue.main.async {
+                guard let self = self, self.flightsEnabled else { return }
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 429 {
+                    NSLog("[Flights] Rate limited by OpenSky")
+                    return
+                }
+                guard let data = data, error == nil,
+                      let jsonStr = String(data: data, encoding: .utf8) else {
+                    NSLog("[Flights] Fetch error: %@", error?.localizedDescription ?? "no data")
+                    return
+                }
+                self.desktopManager.injectRawFlightData(jsonStr)
+            }
+        }.resume()
+    }
+
+    private func fetchAndInjectOpenSkyToken(completion: (() -> Void)? = nil) {
+        guard let clientId = UserDefaults.standard.string(forKey: "opensky-client-id"), !clientId.isEmpty,
+              let clientSecret = UserDefaults.standard.string(forKey: "opensky-client-secret"), !clientSecret.isEmpty else {
+            // No credentials — proceed without a token (anonymous, may hit rate limits)
+            completion?()
+            return
+        }
+
+        let tokenURL = URL(string: "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token")!
+        var request = URLRequest(url: tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = "grant_type=client_credentials&client_id=\(clientId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&client_secret=\(clientSecret.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        request.httpBody = body.data(using: .utf8)
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                guard let data = data,
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let token = json["access_token"] as? String else {
+                    NSLog("[Flights] OpenSky token fetch failed: %@", error?.localizedDescription ?? "unknown")
+                    completion?()
+                    return
+                }
+                let expiresIn = (json["expires_in"] as? Double ?? 1800) - 60
+                self.desktopManager.injectOpenSkyToken(token)
+                // Store token so fetchFlightsNative can use it
+                UserDefaults.standard.set(token, forKey: "opensky-bearer-token")
+                // Schedule proactive refresh
+                self.openSkyTokenTimer?.invalidate()
+                self.openSkyTokenTimer = Timer.scheduledTimer(withTimeInterval: expiresIn, repeats: false) { [weak self] _ in
+                    guard let self = self, self.flightsEnabled else { return }
+                    self.fetchAndInjectOpenSkyToken()
+                }
+                completion?()
+            }
+        }.resume()
     }
 
     @objc private func toggleWeather(_ sender: NSMenuItem) {

--- a/WeatherWallpaper/DesktopWindowManager.swift
+++ b/WeatherWallpaper/DesktopWindowManager.swift
@@ -31,6 +31,10 @@ class DesktopWindowManager: NSObject, WKScriptMessageHandler {
         if let key = UserDefaults.standard.string(forKey: "google-pollen-api-key"), !key.isEmpty {
             injectPollenApiKey(key)
         }
+        if let clientId = UserDefaults.standard.string(forKey: "opensky-client-id"), !clientId.isEmpty,
+           let clientSecret = UserDefaults.standard.string(forKey: "opensky-client-secret"), !clientSecret.isEmpty {
+            injectOpenSkyCredentials(clientId: clientId, clientSecret: clientSecret)
+        }
         if let unit = pendingUnitSystem ?? UserDefaults.standard.string(forKey: "unit-system") {
             injectUnitSystem(unit)
         }
@@ -108,6 +112,17 @@ class DesktopWindowManager: NSObject, WKScriptMessageHandler {
         if let key = UserDefaults.standard.string(forKey: "google-pollen-api-key"), !key.isEmpty {
             let script = WKUserScript(
                 source: "localStorage.setItem('google-pollen-api-key', \(quoteJS(key)));",
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+            config.userContentController.addUserScript(script)
+        }
+
+        // Inject OpenSky credentials before page load
+        if let clientId = UserDefaults.standard.string(forKey: "opensky-client-id"), !clientId.isEmpty,
+           let clientSecret = UserDefaults.standard.string(forKey: "opensky-client-secret"), !clientSecret.isEmpty {
+            let script = WKUserScript(
+                source: "localStorage.setItem('opensky-client-id', \(quoteJS(clientId))); localStorage.setItem('opensky-client-secret', \(quoteJS(clientSecret)));",
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             )
@@ -224,6 +239,30 @@ class DesktopWindowManager: NSObject, WKScriptMessageHandler {
 
     func injectZoom(_ level: Double) {
         let js = "if (window.mapFlyTo) window.mapFlyTo(\(level));"
+        evaluateOnAll(js)
+    }
+
+    func injectOpenSkyCredentials(clientId: String, clientSecret: String) {
+        let js = "if (window.setOpenSkyCredentials) window.setOpenSkyCredentials(\(quoteJS(clientId)), \(quoteJS(clientSecret)));"
+        evaluateOnAll(js)
+    }
+
+    func injectOpenSkyToken(_ token: String) {
+        let js = "if (window.setOpenSkyToken) window.setOpenSkyToken(\(quoteJS(token)));"
+        evaluateOnAll(js)
+    }
+
+    func injectRawFlightData(_ json: String) {
+        // Escape the JSON string safely for inline JS — use a data attribute trick to avoid injection
+        guard let encoded = json.data(using: .utf8)?.base64EncodedString() else { return }
+        let js = """
+        (function(){
+          try {
+            var raw = atob(\(quoteJS(encoded)));
+            if (window.receiveFlightsFromSwift) window.receiveFlightsFromSwift(raw);
+          } catch(e) {}
+        })();
+        """
         evaluateOnAll(js)
     }
 

--- a/WeatherWallpaper/Web/globe.js
+++ b/WeatherWallpaper/Web/globe.js
@@ -201,8 +201,7 @@
 
     function runBackgroundTasks() {
       if (appPaused) return;
-      if (flightsEnabled) fetchFlights();
-
+      // Flights are fetched by Swift (URLSession) to avoid CORS restrictions.
       // Update night overlays
       var tw = map.getSource('twilight-overlay');
       var nt = map.getSource('night-overlay');
@@ -240,6 +239,13 @@
           // We keep bgTasksInterval running for night overlays even if flights are off
         }
       }
+    };
+
+    window.setOpenSkyCredentials = function (clientId, clientSecret) {
+      localStorage.setItem(OPENSKY_CLIENT_ID_KEY, clientId);
+      localStorage.setItem(OPENSKY_CLIENT_SECRET_KEY, clientSecret);
+      // Token is fetched by Swift (URLSession) and injected via setOpenSkyToken
+      openskyBearerToken = null;
     };
 
     // --- Flight state ---
@@ -414,6 +420,23 @@
       map.setLayoutProperty('flights-layer', 'visibility', 'none');
     });
 
+    // --- OpenSky token (injected by Swift via URLSession to avoid CORS) ---
+    var OPENSKY_CLIENT_ID_KEY = 'opensky-client-id';
+    var OPENSKY_CLIENT_SECRET_KEY = 'opensky-client-secret';
+    var openskyBearerToken = null;
+
+    function getOpenSkyClientId() { return localStorage.getItem(OPENSKY_CLIENT_ID_KEY) || ''; }
+    function getOpenSkyClientSecret() { return localStorage.getItem(OPENSKY_CLIENT_SECRET_KEY) || ''; }
+
+    // Called by Swift after it fetches an OAuth2 token via URLSession (no CORS restriction there)
+    window.setOpenSkyToken = function (token) {
+      openskyBearerToken = token || null;
+    };
+
+    function getOpenSkyHeaders() {
+      return openskyBearerToken ? { Authorization: 'Bearer ' + openskyBearerToken } : {};
+    }
+
     // --- Flight fetching (primary view only) ---
     function fetchFlights() {
       if (!mapLoaded || appPaused) return;
@@ -424,7 +447,7 @@
         '&lomin=' + bounds.getWest().toFixed(2) +
         '&lamax=' + bounds.getNorth().toFixed(2) +
         '&lomax=' + bounds.getEast().toFixed(2);
-      fetch(url)
+      fetch(url, { headers: getOpenSkyHeaders() })
         .then(function (res) {
           if (res.status === 429) { console.warn('[Flights] Rate limited, backing off'); return null; }
           if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -459,9 +482,33 @@
         .catch(function (err) { console.warn('[Flights]', err.message || err); });
     }
 
-    // Receiver for flight data relayed from primary view
+    // Called by Swift with the raw JSON string from OpenSky API (all views)
+    window.receiveFlightsFromSwift = function (jsonStr) {
+      if (!mapLoaded || !flightsEnabled) return;
+      var data;
+      try { data = JSON.parse(jsonStr); } catch (e) { return; }
+      if (!data || !Array.isArray(data.states)) return;
+      var newStore = [];
+      for (var i = 0; i < data.states.length && newStore.length < FLIGHTS_MAX; i++) {
+        var s = data.states[i];
+        var lon = s[5], lat = s[6], onGround = s[8];
+        if (onGround || lon == null || lat == null) continue;
+        newStore.push({
+          lon: lon, lat: lat,
+          velocity: s[9] || 0, heading: s[10] || 0,
+          callsign: (s[1] || '').trim(), origin_country: s[2] || '',
+          altitude: s[13] != null ? s[13] : (s[7] || 0),
+          vertical_rate: s[11] || 0
+        });
+      }
+      flightStore = newStore;
+      lastFlightFetch = Date.now();
+      renderFlightPositions();
+    };
+
+    // Receiver for flight data relayed from primary view (kept for secondary screen relay)
     window.receiveFlights = function (data) {
-      if (window.isPrimaryView) return; // primary already has this data
+      if (window.isPrimaryView) return;
       flightStore = data.store || [];
       lastFlightFetch = data.timestamp || Date.now();
       renderFlightPositions();


### PR DESCRIPTION
## Problem

Live flights were completely non-functional for two reasons:

**1. OpenSky Network dropped Basic Auth**
The API now requires OAuth2 (client credentials flow). Anonymous users are
capped at 400 credits/day — a single globe-view request costs 4 credits,
so the quota is exhausted in ~100 fetches and the app silently receives
`429 Too Many Requests`.

**2. WKWebView CORS blocks all OpenSky requests (root cause)**
WKWebView loads pages from `file://` URLs, which have a **null origin**.
OpenSky's servers do not send CORS headers permitting null origins, so
every `fetch()` call to `opensky-network.org` — including the OAuth2 token
request — was silently blocked by the browser before reaching the network.
Flights would never work regardless of credentials as long as networking
was done in JavaScript.

## Fix

Moved all OpenSky networking out of JavaScript and into Swift's `URLSession`,
which has no CORS restrictions:

- **OAuth2 token fetch** — Swift requests a Bearer token from OpenSky's auth
  server and stores it; token is auto-refreshed before expiry via a `Timer`
- **Flight data fetch** — Swift polls `opensky-network.org/api/states/all`
  every 120 seconds with the Bearer token and injects the raw JSON into JS
  via `window.receiveFlightsFromSwift()`
- **New menu item** — "Set OpenSky Credentials…" prompts for `client_id` and
  `client_secret` (stored in `UserDefaults`)
- **README updated** — documents the OpenSky account requirement and setup steps

## How to get OpenSky credentials (free)

1. Create a free account at https://opensky-network.org
2. Go to **My OpenSky → Account** → create a new API client
3. Copy your `client_id` and `client_secret`
4. In the app: menu bar → **Set OpenSky Credentials…** → paste both → Save
5. Toggle **Show Flights**

## Files changed

- `WeatherWallpaper/AppDelegate.swift` — token fetch, flight fetch timer, new menu item
- `WeatherWallpaper/DesktopWindowManager.swift` — `injectOpenSkyToken`, `injectRawFlightData`, `injectOpenSkyCredentials`
- `WeatherWallpaper/Web/globe.js` — removed JS-side OpenSky fetch, added `receiveFlightsFromSwift` and `setOpenSkyToken`
- `README.md` — updated requirements, setup steps, menu bar table, and API notes